### PR TITLE
Improve query execution handling

### DIFF
--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -32,6 +32,9 @@
     {% if error %}
     <div class="alert alert-danger mt-3">{{ error }}</div>
     {% endif %}
+    {% if message %}
+    <div class="alert alert-success mt-3">{{ message }}</div>
+    {% endif %}
     {% if result %}
     <div class="table-responsive mt-4">
         <table class="table table-bordered table-sm">


### PR DESCRIPTION
## Summary
- handle non-result queries in `query_page`
- ensure DB connection closes via `finally`
- always log executed queries
- show success message when no rows returned

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bb201d6e4832b911f30ccf0b3d1a0