### PR TITLE
Limit query result rows

### DIFF
--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -33,7 +33,7 @@
     <div class="alert alert-danger mt-3">{{ error }}</div>
     {% endif %}
     {% if message %}
-    <div class="alert alert-success mt-3">{{ message }}</div>
+    <div class="alert alert-info mt-3">{{ message }}</div>
     {% endif %}
     {% if result %}
     <div class="table-responsive mt-4">


### PR DESCRIPTION
## Summary
- cap query outputs returned in the UI to prevent excessive memory usage
- display an informational message when only the first MAX_ROWS are shown
- clarify MAX_ROWS constant

## Testing
- `python -m py_compile web/views.py`

------
https://chatgpt.com/codex/tasks/task_e_685bba5578fc832bb86e82a3780ca74e