### PR TITLE
Prevent cross-DB queries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 pyodbc
 ldap3
+pytest

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,30 @@
+import pytest
+from web.views import app, _detect_external_db
+
+
+def test_detect_external_db():
+    # same DB
+    assert _detect_external_db('SELECT * FROM table', 'DB1') is None
+    # use statement different
+    assert _detect_external_db('USE OtherDB; SELECT 1', 'DB1') == 'OtherDB'
+    # cross reference
+    assert _detect_external_db('SELECT * FROM OtherDB.dbo.Table1', 'DB1') == 'OtherDB'
+    # cross reference with brackets
+    assert _detect_external_db('SELECT * FROM [OtherDB].dbo.Table1', 'DB1') == 'OtherDB'
+
+
+def test_query_rejects_other_db(monkeypatch):
+    monkeypatch.setattr('web.views.load_permissions', lambda: {'tester': {'main': ['DB1']}})
+    monkeypatch.setattr('web.views.load_sql_servers', lambda: {'main': '10.0.0.1'})
+
+    def fake_get_conn(ip):
+        raise AssertionError('get_conn should not be called')
+
+    monkeypatch.setattr('web.views.get_conn', fake_get_conn)
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+
+    resp = client.post('/query', data={'database': 'main::DB1', 'query': 'SELECT * FROM OtherDB.dbo.tbl'}, follow_redirects=True)
+    assert b'farkli bir veritaban' in resp.data.lower()

--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -30,7 +30,7 @@
         <button type="submit" class="btn btn-success">Çalıştır</button>
     </form>
     {% if error %}
-    <div class="alert alert-danger mt-3">{{ error }}</div>
+    <div class="alert alert-danger mt-3" role="alert">{{ error }}</div>
     {% endif %}
     {% if message %}
     <div class="alert alert-success mt-3">{{ message }}</div>

--- a/web/views.py
+++ b/web/views.py
@@ -15,6 +15,27 @@ from web.paths import (
     QUERY_LOG_PATH,
 )
 
+def _detect_external_db(query, target_db):
+    """Return referenced DB name if query points to another database."""
+    use_match = re.search(r"\bUSE\s+(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))", query, re.IGNORECASE)
+    if use_match:
+        db = use_match.group('br') or use_match.group('plain')
+        if db.lower() != target_db.lower():
+            return db
+
+    patterns = [
+        re.compile(r"(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))\s*\.\s*(?:\w+\s*\.)\s*\w+", re.IGNORECASE),
+        re.compile(r"(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))\s*\.\.\s*(?:\[[^\]]+\]|\w+)", re.IGNORECASE),
+    ]
+
+    for pat in patterns:
+        for m in pat.finditer(query):
+            db = m.group('br') or m.group('plain')
+            if db.lower() != target_db.lower():
+                return db
+
+    return None
+
 app = Flask(__name__)
 app.secret_key = 'your-secret-key'
 
@@ -730,27 +751,31 @@ def query_page():
                 if not ip:
                     error = "Sunucu bulunamadı."
                 else:
-                    try:
-                        conn = get_conn(ip)
-                        cursor = conn.cursor()
-                        cursor.execute(f"USE [{database}]")
-                        cursor.execute(query_text)
-                        if cursor.description is None:
-                            result = []
-                            columns = []
-                            message = "Query executed successfully."
-                        else:
-                            rows = cursor.fetchall()
-                            columns = [col[0] for col in cursor.description]
-                            result = [list(row) for row in rows]
-                        log_query(username, f"{prefix}/{database}", query_text)
-                    except Exception as e:
-                        error = f"Sorgu hatası: {e}"
-                    finally:
+                    other_db = _detect_external_db(query_text, database)
+                    if other_db:
+                        error = f"Sorgu içerisinde farklı bir veritabanı ('{other_db}') referansı tespit edildi."
+                    else:
                         try:
-                            conn.close()
-                        except Exception:
-                            pass
+                            conn = get_conn(ip)
+                            cursor = conn.cursor()
+                            cursor.execute(f"USE [{database}]")
+                            cursor.execute(query_text)
+                            if cursor.description is None:
+                                result = []
+                                columns = []
+                                message = "Query executed successfully."
+                            else:
+                                rows = cursor.fetchall()
+                                columns = [col[0] for col in cursor.description]
+                                result = [list(row) for row in rows]
+                            log_query(username, f"{prefix}/{database}", query_text)
+                        except Exception as e:
+                            error = f"Sorgu hatası: {e}"
+                        finally:
+                            try:
+                                conn.close()
+                            except Exception:
+                                pass
 
     return render_template(
         'query.html',


### PR DESCRIPTION
## Summary
- add parser `_detect_external_db` for catching USE or other DB references
- block cross database queries in `query_page`
- show errors with `role="alert"` for accessibility
- add pytest with a unit test for this logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'web')*

------
https://chatgpt.com/codex/tasks/task_e_685bba5458a8832b8a251343e7fcd647