### PR TITLE
Improve cross DB query detection

### DIFF
--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,8 @@
+import os
+import sys
 import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from web.views import app, _detect_external_db
 
 

--- a/web/views.py
+++ b/web/views.py
@@ -28,8 +28,16 @@ def _detect_external_db(query, target_db):
             return db
 
     patterns = [
-        re.compile(r"(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))\s*\.\s*(?:\w+\s*\.)\s*\w+", re.IGNORECASE),
-        re.compile(r"(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))\s*\.\.\s*(?:\[[^\]]+\]|\w+)", re.IGNORECASE),
+        # three-part name: [DB].[schema].[table] or DB.schema.table (schema/table optional brackets)
+        re.compile(
+            r"(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))\s*\.\s*(?:\[(?:[^\]]+)\]|\w+)\s*\.\s*(?:\[(?:[^\]]+)\]|\w+)",
+            re.IGNORECASE,
+        ),
+        # two-part name using .. syntax: DB..table
+        re.compile(
+            r"(?:\[(?P<br>[^\]]+)\]|(?P<plain>\w+))\s*\.\.\s*(?:\[[^\]]+\]|\w+)",
+            re.IGNORECASE,
+        ),
     ]
 
     for pat in patterns:


### PR DESCRIPTION
## Summary
- fix `_detect_external_db` to catch bracketed three-part names
- adjust tests to ensure package path is available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685bd161a174832bbb0c3b6b96582726