### PR TITLE
Use modal confirmation for UPDATE/DELETE

### DIFF
--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>SQL Sorgu</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </head>
 <body class="bg-light">
 <div class="container my-4">
@@ -57,6 +58,31 @@
         </table>
     </div>
     {% endif %}
+    {% if show_confirm %}
+    <div class="modal fade" id="confirmModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Sorgu Onayı</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p>{{ affected }} kayıt etkilenecek.</p>
+                    <textarea class="form-control" rows="6" readonly>{{ pending_query }}</textarea>
+                </div>
+                <div class="modal-footer">
+                    <form method="post" action="{{ url_for('execute_query') }}" class="d-inline">
+                        <button type="submit" class="btn btn-danger">Onayla</button>
+                    </form>
+                    <a href="{{ url_for('query_page') }}" class="btn btn-secondary" data-bs-dismiss="modal">İptal</a>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
 </div>
+{% if show_confirm %}
+<script>var m = new bootstrap.Modal(document.getElementById('confirmModal')); m.show();</script>
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace confirmation page with Bootstrap modal
- keep pending query info in session until executed
- show confirmation modal when UPDATE or DELETE detected
- adjust tests for new modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685bd88b89f8832bac68acf41e8555aa