### PR TITLE
Display query logs in admin panel

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,20 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from web.views import app
+
+def test_admin_shows_query_log(monkeypatch):
+    monkeypatch.setattr('web.views.is_admin', lambda: True)
+    monkeypatch.setattr('web.views.load_sql_servers', lambda: {})
+    monkeypatch.setattr('web.views.get_conn', lambda ip: (_ for _ in ()).throw(Exception()))
+    monkeypatch.setattr('web.views.load_query_logs', lambda limit=100: [
+        {'ts': '2024-01-01 12:00:00', 'user': 'tester', 'db': 'main/DB1', 'query': 'SELECT 1'}
+    ])
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+    resp = client.get('/admin')
+    data = resp.data.decode('utf-8')
+    assert 'SQL Sorgu Logu' in data
+    assert 'SELECT 1' in data
+

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -17,6 +17,8 @@
             <a href="/logout" class="btn btn-outline-danger btn-sm ms-2">Çıkış</a>
         </div>
     </div>
+    <div class="row">
+        <div class="col-md-6">
 
     <!-- ✅ Kullanıcı Listesi -->
     <div class="card mb-4">
@@ -115,6 +117,40 @@
                     {% endfor %}
                 </tbody>
             </table>
+        </div>
+        </div>
+    </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">📝 SQL Sorgu Logu</div>
+                <div class="card-body">
+                    <div class="table-responsive" style="max-height: 600px; overflow:auto;">
+                        <table class="table table-sm table-striped align-middle">
+                            <thead class="table-light">
+                                <tr>
+                                    <th>Zaman</th>
+                                    <th>Kullanıcı</th>
+                                    <th>Veritabanı</th>
+                                    <th>Sorgu</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for log in query_logs %}
+                                <tr>
+                                    <td>{{ log.ts }}</td>
+                                    <td>{{ log.user }}</td>
+                                    <td>{{ log.db }}</td>
+                                    <td>{{ log.query }}</td>
+                                </tr>
+                                {% else %}
+                                <tr><td colspan="4">Log kaydı yok.</td></tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- show query logs in the admin page
- refactor admin template into two columns
- add helper to load recent query log lines
- test new admin log display

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685becc336f8832bad2faa32ea10cf63