### PR TITLE
Use environment variables for configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,17 +1,18 @@
 from flask import Flask, request, jsonify
 import pyodbc
+import os
 
 app = Flask(__name__)
 
 # SQL bağlantı bilgileri
-PROD_SQL = "10.10.10.61"
-DEV_SQL = "172.35.10.29"
-SQL_USER = "devflask"
-SQL_PASSWORD = "StrongP@ss123"
+PROD_SQL = os.getenv("PROD_SQL_SERVER", "10.10.10.61")
+DEV_SQL = os.getenv("DEV_SQL_SERVER", "172.35.10.29")
+SQL_USER = os.getenv("SQL_USER", "devflask")
+SQL_PASSWORD = os.getenv("SQL_PASSWORD", "StrongP@ss123")
 
 # Dosya yolları
-BACKUP_SHARE_PATH = r"\\172.35.10.29\Backups"
-DEV_DATA_PATH = r"D:\SQLData"
+BACKUP_SHARE_PATH = os.getenv("BACKUP_SHARE_PATH", r"\\172.35.10.29\Backups")
+DEV_DATA_PATH = os.getenv("DEV_DATA_PATH", r"D:\SQLData")
 
 def get_conn(server_ip):
     conn = pyodbc.connect(

--- a/web/views.py
+++ b/web/views.py
@@ -62,19 +62,19 @@ def _starts_with_update_or_delete(sql: str) -> bool:
     return bool(_DML_START_RE.match(sql))
 
 app = Flask(__name__)
-app.secret_key = 'your-secret-key'
+app.secret_key = os.getenv("SECRET_KEY", "your-secret-key")
 
 # LDAP ayarları
-LDAP_SERVER = 'ldap://10.0.0.201'
-LDAP_DOMAIN = 'BAYLAN'
+LDAP_SERVER = os.getenv("LDAP_SERVER", "ldap://10.0.0.201")
+LDAP_DOMAIN = os.getenv("LDAP_DOMAIN", "BAYLAN")
 
 # SQL bağlantı bilgileri
-PROD_SQL = "10.10.10.61"
-DEV_SQL = "172.35.10.29"
-SQL_USER = "devflask"
-SQL_PASSWORD = "StrongP@ss123"
-BACKUP_SHARE_PATH = r"\\172.35.10.29\Backups"
-DEV_DATA_PATH = r"D:\SQLData"
+PROD_SQL = os.getenv("PROD_SQL_SERVER", "10.10.10.61")
+DEV_SQL = os.getenv("DEV_SQL_SERVER", "172.35.10.29")
+SQL_USER = os.getenv("SQL_USER", "devflask")
+SQL_PASSWORD = os.getenv("SQL_PASSWORD", "StrongP@ss123")
+BACKUP_SHARE_PATH = os.getenv("BACKUP_SHARE_PATH", r"\\172.35.10.29\Backups")
+DEV_DATA_PATH = os.getenv("DEV_DATA_PATH", r"D:\SQLData")
 
 # Wazuh syslog configuration
 WAZUH_SYSLOG_HOST = os.getenv("WAZUH_SYSLOG_HOST", "127.0.0.1")


### PR DESCRIPTION
## Summary
- source app settings like secret key and SQL credentials from environment
- add environment fallbacks for LDAP and backup paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685d411003c8832b884a300e3409fea5