### PR TITLE
Fix consecutive update/delete queries

### DIFF
--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -15,7 +15,7 @@
             <a href="/logout" class="btn btn-outline-danger btn-sm ms-2">Çıkış</a>
         </div>
     </div>
-    <form method="post">
+    <form method="post" action="{{ url_for('query_page') }}">
         <div class="mb-3">
             <label for="database" class="form-label">Prod Veritabanı</label>
             <select name="database" id="database" class="form-select" required>


### PR DESCRIPTION
## Summary
- ensure query form posts to the `/query` endpoint consistently

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e43b42768832b8a2adc65cfe75361