### PR TITLE
Add syslog logging for DB operations

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,7 +3,7 @@ import sys
 import json
 import logging
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from web.views import app, log_query
+from web.views import app, log_query, log_action
 
 def test_admin_shows_query_log(monkeypatch):
     monkeypatch.setattr('web.views.is_admin', lambda: True)
@@ -41,4 +41,26 @@ def test_log_query_emits_syslog(monkeypatch):
     assert data['user'] == 'tester'
     assert data['database'] == 'main/DB1'
     assert data['query'] == 'SELECT 1'
+
+
+def test_log_action_emits_syslog(monkeypatch):
+    messages = []
+
+    class DummyHandler(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    dummy_logger = logging.getLogger("dummy_action")
+    dummy_logger.setLevel(logging.INFO)
+    dummy_logger.addHandler(DummyHandler())
+
+    monkeypatch.setattr('web.views.query_logger', dummy_logger)
+
+    log_action('tester', 'create_dev_db', prod_db='BMS', dev_db='main_BMS_tester')
+
+    assert len(messages) == 1
+    data = json.loads(messages[0])
+    assert data['user'] == 'tester'
+    assert data['action'] == 'create_dev_db'
+    assert data['dev_db'] == 'main_BMS_tester'
 


### PR DESCRIPTION
## Summary
- log create/delete operations with new `log_action` helper
- emit syslog messages for create/delete routes
- test syslog logging of actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e45ac3a40832bacca919fee9ec080