### PR TITLE
Allow DB permissions without query ops

### DIFF
--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -64,24 +64,17 @@
                                         <input class="form-check-input" type="checkbox" id="allow-{{ safe_user }}" name="allow_query" {% if user_perms.get('allow_query', True) %}checked{% endif %}>
                                         <label class="form-check-label" for="allow-{{ safe_user }}">Sorgu Çalıştırma İzni</label>
                                     </div>
-                                    {% for server, db_map in user_perms.items() %}
-                                        {% if server != 'allow_query' %}
+                                    {% for server, dbs in prod_dbs_grouped.items() %}
                                         <h6 class="mt-2">{{ server }} sunucusu</h6>
-                                        {% for db, ops in db_map.items() %}
-                                        <div class="mb-2">
-                                            <label class="form-label fw-bold">{{ db }}</label><br>
-                                            {% for op in ['SELECT','INSERT','UPDATE','DELETE'] %}
-                                            <div class="form-check form-check-inline">
-                                                <input class="form-check-input" type="checkbox"
-                                                       name="perm-{{ user }}-{{ server }}::{{ db }}::{{ op }}"
-                                                       id="chk-{{ user }}-{{ server }}::{{ db }}::{{ op }}"
-                                                       {% if op in ops %}checked{% endif %}>
-                                                <label class="form-check-label" for="chk-{{ user }}-{{ server }}::{{ db }}::{{ op }}">{{ op }}</label>
-                                            </div>
-                                            {% endfor %}
+                                        {% for db in dbs %}
+                                        <div class="form-check">
+                                            <input class="form-check-input" type="checkbox"
+                                                   name="db-{{ user }}-{{ server }}::{{ db }}"
+                                                   id="dbchk-{{ user }}-{{ server }}::{{ db }}"
+                                                   {% if user_perms.get(server, {}).get(db) is not none %}checked{% endif %}>
+                                            <label class="form-check-label" for="dbchk-{{ user }}-{{ server }}::{{ db }}">{{ db }}</label>
                                         </div>
                                         {% endfor %}
-                                        {% endif %}
                                     {% endfor %}
                                 </div>
                                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- list all prod DBs in admin permissions modal
- capture DB selections in `update_permissions` even when no operations are marked

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e60b0bf04832b95daea3cb518af85