### PR TITLE
Fix duplicate allow_query redirects

### DIFF
--- a/web/views.py
+++ b/web/views.py
@@ -927,12 +927,6 @@ def query_page():
             prod_dbs.append({'prefix': prefix, 'db': db})
 
     if not allow_query:
-        return redirect(url_for('query_page'))
-
-    if not allow_query:
-        return redirect(url_for('query_page'))
-
-    if not allow_query:
         return render_template(
             'query.html',
             username=username,


### PR DESCRIPTION
## Summary
- simplify query_page authorization

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e6ab86c34832bb0ddbb475fd45324