### PR TITLE
Hide query button when user lacks permission

### DIFF
--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -22,7 +22,9 @@
             {% if is_admin %}
             <a href="/admin" class="btn btn-outline-primary btn-sm">🔧 Admin Panel</a>
             {% endif %}
+            {% if allow_query %}
             <a href="/query" class="btn btn-outline-success btn-sm ms-2">SQL Sorgu</a>
+            {% endif %}
             <a href="/logout" class="btn btn-outline-danger btn-sm ms-2">Çıkış</a>
         </div>
     </div>

--- a/web/views.py
+++ b/web/views.py
@@ -671,6 +671,7 @@ def dashboard():
     # Kullanıcının yetkili olduğu veritabanları (yeni format)
     permissions = load_permissions()
     user_perms = permissions.get(username, {})
+    allow_query = user_perms.get('allow_query', True)
     logger.debug("user_perms: %s", user_perms)
 
     prod_dbs = []
@@ -708,7 +709,8 @@ def dashboard():
         dev_dbs=dev_dbs,
         active_job=active_job,
         job_queue=list(job_queue),
-        is_admin=is_admin()
+        is_admin=is_admin(),
+        allow_query=allow_query
     )
 
 @app.route('/delete', methods=['POST'])


### PR DESCRIPTION
## Summary
- respect `allow_query` permission in the dashboard
- show the SQL query button only when user is allowed to query

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e6e5a8970832b83e20c8ceaf7bbfa