### PR TITLE
Enable disabling allow_query permission

### DIFF
--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -96,3 +96,19 @@ def test_update_permissions_preserves_ops(monkeypatch):
 
     assert saved['user1']['main']['DB1'] == ['SELECT', 'INSERT']
 
+
+def test_update_permissions_disable_allow_query(monkeypatch):
+    perms = {'user1': {'allow_query': True, 'main': {}}}
+    saved = {}
+    monkeypatch.setattr('web.views.is_admin', lambda: True)
+    monkeypatch.setattr('web.views.load_permissions', lambda: json.loads(json.dumps(perms)))
+    monkeypatch.setattr('web.views.save_permissions', lambda p: saved.update(p))
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'admin'
+
+    client.post('/admin/update-permissions', data={'user': 'user1', 'allow_query': 'off'})
+
+    assert saved['user1']['allow_query'] is False
+

--- a/web/templates/admin.html
+++ b/web/templates/admin.html
@@ -61,7 +61,8 @@
                                     <input type="hidden" name="user" value="{{ user }}">
                                     {% set user_perms = permissions.get(user, {}) %}
                                     <div class="form-check form-switch mb-3">
-                                        <input class="form-check-input" type="checkbox" id="allow-{{ safe_user }}" name="allow_query" {% if user_perms.get('allow_query', True) %}checked{% endif %}>
+                                        <input class="form-check-input" type="checkbox" id="allow-{{ safe_user }}" name="allow_query" value="on" {% if user_perms.get('allow_query', True) %}checked{% endif %}>
+                                        <input type="hidden" name="allow_query" value="off">
                                         <label class="form-check-label" for="allow-{{ safe_user }}">Sorgu Çalıştırma İzni</label>
                                     </div>
                                     {% for server, dbs in prod_dbs_grouped.items() %}


### PR DESCRIPTION
## Summary
- add a hidden allow_query=off input right after the checkbox
- test that submitting allow_query=off saves the permission as False

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e728c1238832b96677ae904df3b76