### PR TITLE
Resolve query form validation error

### DIFF
--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -36,7 +36,7 @@
                 </div>
                 <div class="mb-3">
                     <label for="query" class="form-label">Sorgu</label>
-                    <textarea name="query" id="query" required>{{ request.form.query }}</textarea>
+                    <textarea name="query" id="query">{{ request.form.query }}</textarea>
                 </div>
                 <button type="submit" class="btn btn-success">Çalıştır</button>
             </form>


### PR DESCRIPTION
## Summary
- fix browser validation failure on query page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e7ed1a8a0832b87416c4691cfbdeb