### PR TITLE
Sort table names alphabetically

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -53,7 +53,7 @@ def test_tables_returns_list(monkeypatch):
     resp = client.get('/api/tables?db=main::DB1')
     assert resp.status_code == 200
     data = json.loads(resp.data.decode('utf-8'))
-    assert data['tables'] == ['dbo.Users', 'dbo.Orders']
+    assert data['tables'] == ['dbo.Orders', 'dbo.Users']
     assert executed_ip == ['10.0.0.1']
     assert "USE [DB1]" in executed_sql[0]
 

--- a/web/views.py
+++ b/web/views.py
@@ -298,10 +298,11 @@ def api_tables():
         cursor = conn.cursor()
         cursor.execute(f"USE [{database}]")
         cursor.execute(
-            "SELECT TABLE_SCHEMA + '.' + TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE'"
+            "SELECT TABLE_SCHEMA + '.' + TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
+            "WHERE TABLE_TYPE='BASE TABLE'"
         )
         rows = cursor.fetchall()
-        tables = [row[0] for row in rows]
+        tables = sorted(row[0] for row in rows)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     finally:


### PR DESCRIPTION
## Summary
- sort table names in `/api/tables`
- update tests for alphabetical order

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e84b93d20832bbb4387cc6166a996