### PR TITLE
Improve table list UI and API

### DIFF
--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -26,7 +26,7 @@ def test_tables_returns_list(monkeypatch):
 
     executed_ip = []
     executed_sql = []
-    tables = [('dbo.Users',), ('dbo.Orders',)]
+    tables = [('dbo.Users', 'BASE TABLE'), ('dbo.Orders', 'VIEW')]
 
     class FakeCursor:
         def execute(self, sql):
@@ -53,7 +53,10 @@ def test_tables_returns_list(monkeypatch):
     resp = client.get('/api/tables?db=main::DB1')
     assert resp.status_code == 200
     data = json.loads(resp.data.decode('utf-8'))
-    assert data['tables'] == ['dbo.Orders', 'dbo.Users']
+    assert data['tables'] == [
+        {'name': 'dbo.Orders', 'type': 'VIEW'},
+        {'name': 'dbo.Users', 'type': 'BASE TABLE'}
+    ]
     assert executed_ip == ['10.0.0.1']
     assert "USE [DB1]" in executed_sql[0]
 

--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -12,6 +12,19 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/show-hint.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/hint/sql-hint.min.js"></script>
+    <style>
+        #table-list {
+            max-height: 70vh;
+            overflow-y: auto;
+        }
+        #table-list .table-name {
+            display: inline-block;
+            max-width: 100%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+    </style>
 </head>
 <body class="bg-light">
 <div class="container my-4">
@@ -23,7 +36,7 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-3" id="table-list"></div>
+        <div class="col-3" id="table-list" style="overflow-y:auto;"></div>
         <div class="col-9">
             <form method="post" action="{{ url_for('query_page') }}">
                 <div class="mb-3">
@@ -126,12 +139,19 @@ function loadTableList() {
             const list = document.createElement('ul');
             list.className = 'list-group';
             hintTables = {};
-            (data.tables || []).forEach(tbl => {
+            (data.tables || []).forEach(item => {
                 const li = document.createElement('li');
-                li.className = 'list-group-item py-1';
-                li.textContent = tbl;
+                li.className = 'list-group-item py-1 d-flex justify-content-between';
+                const nameSpan = document.createElement('span');
+                nameSpan.className = 'table-name';
+                nameSpan.textContent = item.name;
+                li.appendChild(nameSpan);
+                const badge = document.createElement('span');
+                badge.className = 'badge bg-secondary';
+                badge.textContent = item.type;
+                li.appendChild(badge);
                 list.appendChild(li);
-                hintTables[tbl] = [];
+                hintTables[item.name] = [];
             });
             container.appendChild(list);
             if (editor) editor.setOption('hintOptions', { tables: hintTables });

--- a/web/views.py
+++ b/web/views.py
@@ -298,11 +298,14 @@ def api_tables():
         cursor = conn.cursor()
         cursor.execute(f"USE [{database}]")
         cursor.execute(
-            "SELECT TABLE_SCHEMA + '.' + TABLE_NAME FROM INFORMATION_SCHEMA.TABLES "
-            "WHERE TABLE_TYPE='BASE TABLE'"
+            "SELECT TABLE_SCHEMA + '.' + TABLE_NAME AS tbl, TABLE_TYPE "
+            "FROM INFORMATION_SCHEMA.TABLES"
         )
         rows = cursor.fetchall()
-        tables = sorted(row[0] for row in rows)
+        tables = sorted(
+            [{"name": row[0], "type": row[1]} for row in rows],
+            key=lambda x: x["name"],
+        )
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     finally:


### PR DESCRIPTION
## Summary
- return table type info from `/api/tables`
- show table type badges and scrollable table list in query page
- update table list tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685e96d5ade0832bb4aa72d80e3d62ce