### PR TITLE
Add columns endpoint and UI display

### DIFF
--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,0 +1,61 @@
+import json
+from web.views import app
+
+ALL_OPS = ['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+
+
+def test_columns_requires_login():
+    client = app.test_client()
+    resp = client.get('/api/columns?db=main::DB1&table=dbo.Users')
+    assert resp.status_code == 403
+
+
+def test_columns_permission(monkeypatch):
+    monkeypatch.setattr('web.views.load_permissions', lambda: {'tester': {'allow_query': True, 'main': {'DB2': ALL_OPS}}})
+    monkeypatch.setattr('web.views.load_sql_servers', lambda: {'main': '10.0.0.1'})
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+    resp = client.get('/api/columns?db=main::DB1&table=dbo.Users')
+    assert resp.status_code == 403
+
+
+def test_columns_returns_list(monkeypatch):
+    monkeypatch.setattr('web.views.load_permissions', lambda: {'tester': {'allow_query': True, 'main': {'DB1': ALL_OPS}}})
+    monkeypatch.setattr('web.views.load_sql_servers', lambda: {'main': '10.0.0.1'})
+
+    executed_ip = []
+    executed_sql = []
+    cols = [('Id', 'int'), ('Name', 'nvarchar')]
+
+    class FakeCursor:
+        def execute(self, sql, *params):
+            executed_sql.append(sql)
+        def fetchall(self):
+            return cols
+
+    class FakeConn:
+        def cursor(self):
+            return FakeCursor()
+        def close(self):
+            pass
+
+    def fake_get_conn(ip):
+        executed_ip.append(ip)
+        return FakeConn()
+
+    monkeypatch.setattr('web.views.get_conn', fake_get_conn)
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+
+    resp = client.get('/api/columns?db=main::DB1&table=dbo.Users')
+    assert resp.status_code == 200
+    data = json.loads(resp.data.decode('utf-8'))
+    assert data['columns'] == [
+        {'name': 'Id', 'type': 'int'},
+        {'name': 'Name', 'type': 'nvarchar'}
+    ]
+    assert executed_ip == ['10.0.0.1']
+    assert "USE [DB1]" in executed_sql[0]

--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -36,7 +36,10 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-3" id="table-list" style="overflow-y:auto;"></div>
+        <div class="col-3">
+            <div id="table-list" style="overflow-y:auto;"></div>
+            <div id="column-info" class="mt-3"></div>
+        </div>
         <div class="col-9">
             <form method="post" action="{{ url_for('query_page') }}">
                 <div class="mb-3">
@@ -150,6 +153,7 @@ function loadTableList() {
                 badge.className = 'badge bg-secondary';
                 badge.textContent = item.type;
                 li.appendChild(badge);
+                li.addEventListener('click', () => loadColumns(item.name));
                 list.appendChild(li);
                 hintTables[item.name] = [];
             });
@@ -157,6 +161,38 @@ function loadTableList() {
             if (editor) editor.setOption('hintOptions', { tables: hintTables });
         })
         .catch(err => console.error('Table list failed', err));
+}
+
+function loadColumns(tableName) {
+    const db = document.getElementById('database').value;
+    fetch(`/api/columns?db=${encodeURIComponent(db)}&table=${encodeURIComponent(tableName)}`)
+        .then(res => res.json())
+        .then(data => {
+            const info = document.getElementById('column-info');
+            if (!info) return;
+            info.innerHTML = '';
+            const title = document.createElement('h6');
+            title.textContent = tableName;
+            info.appendChild(title);
+            const ul = document.createElement('ul');
+            ul.className = 'list-group';
+            (data.columns || []).forEach(col => {
+                const li = document.createElement('li');
+                li.className = 'list-group-item py-1 d-flex justify-content-between';
+                const nameSpan = document.createElement('span');
+                nameSpan.textContent = col.name;
+                li.appendChild(nameSpan);
+                const badge = document.createElement('span');
+                badge.className = 'badge bg-secondary';
+                badge.textContent = col.type;
+                li.appendChild(badge);
+                ul.appendChild(li);
+            });
+            info.appendChild(ul);
+            hintTables[tableName] = (data.columns || []).map(c => c.name);
+            if (editor) editor.setOption('hintOptions', { tables: hintTables });
+        })
+        .catch(err => console.error('Column list failed', err));
 }
 
 document.getElementById('database').addEventListener('change', loadTableList);


### PR DESCRIPTION
## Summary
- add `/api/columns` endpoint to query table column metadata
- display column metadata in query page and update autocomplete
- test new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ea0440634832bb421c3b47b5c6441