### PR TITLE
Implement active job progress polling

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,19 @@
+import os, sys, json
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from web.views import app
+
+
+def test_active_job_progress_element(monkeypatch):
+    monkeypatch.setattr('web.views.load_sql_servers', lambda: {})
+    monkeypatch.setattr('web.views.load_permissions', lambda: {})
+    monkeypatch.setattr('web.views.is_admin', lambda: False)
+    monkeypatch.setattr('web.views.get_conn', lambda ip: (_ for _ in ()).throw(Exception()))
+    monkeypatch.setattr('web.views.active_job', {'prod_db': 'BMS', 'dev_db': 'main_BMS_tester', 'username': 'tester'})
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+    resp = client.get('/dashboard')
+    html = resp.data.decode('utf-8')
+    assert 'id="active-job-status"' in html
+    assert 'progress?dev_db=main_BMS_tester' in html
+

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -32,6 +32,7 @@
     {% if active_job %}
     <div class="alert alert-info">
         <strong>Aktif İşlem:</strong> {{ active_job.prod_db }} → {{ active_job.dev_db }} ({{ active_job.username }})
+        <span id="active-job-status" class="ms-2"></span>
     </div>
     {% endif %}
 
@@ -145,6 +146,29 @@ function updateProgress(dev_db) {
     updateProgress("{{ dev }}");
 {% endfor %}
 </script>
+{% if active_job %}
+<script>
+(function pollActiveJob() {
+    const el = document.getElementById('active-job-status');
+    function poll() {
+        fetch('/progress?dev_db={{ active_job.dev_db }}')
+            .then(res => res.json())
+            .then(data => {
+                if (el) {
+                    const percent = data.percent_complete || 0;
+                    const stage = data.stage || '';
+                    el.textContent = `${stage}: %${percent}`;
+                }
+                if (data.status !== 'done') {
+                    setTimeout(poll, 3000);
+                }
+            })
+            .catch(err => console.error(err));
+    }
+    poll();
+})();
+</script>
+{% endif %}
 <script>
 let previousDevDbs = {{ dev_dbs | tojson }};
 


### PR DESCRIPTION
## Summary
- extend dashboard active job section with progress status element
- poll `/progress` for active job and update UI
- add regression test to verify active job progress element appears

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685feb12a418832b93d621cb5c3cd7a8