### PR TITLE
Improve active job tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,20 @@ Bağımlılıkların kurulu olduğundan emin olun.
 ```
 
 Anahtar eksik olduğunda uygulama varsayılan olarak `true` kabul eder ancak yetkiyi kapatabilmek için dosyanın güncellenmesi gerekir.
+
+## Aktif İşler Yapısı
+
+Yedek alma ve geri yükleme gibi uzun süren işlemler bellek içindeki
+`active_jobs` sözlüğünde izlenir. Anahtar, hedef geliştirme veritabanı
+ismidir. Değer aşağıdaki alanları içerir:
+
+```python
+{
+    "stage": "backup" | "analyze" | "restore",
+    "percent": int,
+    "prod_db": "KaynakDB",
+    "source_sql": "10.0.0.1"
+}
+```
+
+`/progress` uç noktası bu bilgileri kullanarak işlemin durumunu döndürür.

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,43 @@
+import json
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from web.views import app, active_jobs
+
+
+def test_progress_reports_running(monkeypatch):
+    dev_db = 'main_DB1_tester'
+    job_info = {
+        'stage': 'backup',
+        'percent': 0,
+        'prod_db': 'DB1',
+        'source_sql': '10.0.0.2',
+    }
+    monkeypatch.setitem(active_jobs, dev_db, job_info)
+
+    def fake_get_conn(ip):
+        class FakeCursor:
+            def execute(self, sql, *params):
+                pass
+            def fetchall(self):
+                if ip == '10.0.0.2':
+                    Row = type('Row', (), {
+                        'percent_complete': 12,
+                        'command': 'BACKUP DATABASE',
+                        'sql_text': 'BACKUP DATABASE DB1'
+                    })
+                    return [Row()]
+                return []
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+            def close(self):
+                pass
+        return FakeConn()
+
+    monkeypatch.setattr('web.views.get_conn', fake_get_conn)
+
+    client = app.test_client()
+    resp = client.get('/progress?dev_db=' + dev_db)
+    data = json.loads(resp.data.decode('utf-8'))
+    assert data['stage'] == 'backup'
+    assert data['status'] == 'running'


### PR DESCRIPTION
## Summary
- keep prod_db and source_sql in `active_jobs` when stages update
- document `active_jobs` structure
- add test covering `/progress` on a custom SQL server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685fed633014832b86ebd56b8fa68a20