### PR TITLE
Enable cancelling queued jobs

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -17,3 +17,41 @@ def test_active_job_progress_element(monkeypatch):
     assert 'id="active-job-status"' in html
     assert 'progress?dev_db=main_BMS_tester' in html
 
+
+def test_dashboard_shows_cancel_for_queued_job(monkeypatch):
+    from collections import deque
+    q = deque([
+        {'prod_db': 'BMS', 'dev_db': 'main_BMS_tester', 'username': 'tester'},
+        {'prod_db': 'BMS2', 'dev_db': 'main_BMS2_other', 'username': 'other'},
+    ])
+    monkeypatch.setattr('web.views.job_queue', q)
+    monkeypatch.setattr('web.views.active_job', {'dummy': True})
+    monkeypatch.setattr('web.views.load_sql_servers', lambda: {})
+    monkeypatch.setattr('web.views.load_permissions', lambda: {})
+    monkeypatch.setattr('web.views.is_admin', lambda: False)
+    monkeypatch.setattr('web.views.get_conn', lambda ip: (_ for _ in ()).throw(Exception()))
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+    resp = client.get('/dashboard')
+    html = resp.data.decode('utf-8')
+    assert html.count('action="/cancel-queued"') == 1
+
+
+def test_cancel_queued_removes_job(monkeypatch):
+    from collections import deque
+    q = deque([
+        {'prod_db': 'BMS', 'dev_db': 'main_BMS_tester', 'username': 'tester'}
+    ])
+    monkeypatch.setattr('web.views.job_queue', q)
+    monkeypatch.setattr('web.views.active_job', {'dummy': True})
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['user'] = 'tester'
+
+    client.post('/cancel-queued', data={'dev_db': 'main_BMS_tester'})
+
+    assert len(q) == 0
+

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -41,7 +41,15 @@
         <strong>Kuyruktaki İşler:</strong>
         <ul class="mb-0">
             {% for job in job_queue %}
-            <li>{{ job.prod_db }} → {{ job.dev_db }} ({{ job.username }})</li>
+            <li>
+                {{ job.prod_db }} → {{ job.dev_db }} ({{ job.username }})
+                {% if job.username == username %}
+                <form method="post" action="/cancel-queued" class="d-inline ms-2">
+                    <input type="hidden" name="dev_db" value="{{ job.dev_db }}">
+                    <button type="submit" class="btn btn-sm btn-outline-danger">İptal</button>
+                </form>
+                {% endif %}
+            </li>
             {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
## Summary
- add cancel button for queued jobs on dashboard
- cover new cancel functionality with tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685ff2942f90832b8cec068976f5687a