### PR TITLE
Fix table list UI

### DIFF
--- a/web/templates/query.html
+++ b/web/templates/query.html
@@ -149,10 +149,6 @@ function loadTableList() {
                 nameSpan.textContent = item.name;
                 nameSpan.title = item.name;
                 li.appendChild(nameSpan);
-                const badge = document.createElement('span');
-                badge.className = 'badge bg-secondary';
-                badge.textContent = item.type;
-                li.appendChild(badge);
                 li.addEventListener('click', () => loadColumns(item.name));
                 list.appendChild(li);
                 hintTables[item.name] = [];


### PR DESCRIPTION
## Summary
- hide table type badges entirely in query page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_685ff48fdba8832bae6e4bc2f3baae6d